### PR TITLE
Fixed for newer version of Parsec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Parsec Launcher for OSMC
+# Parsec Launcher for OSMC - Fixed August 2020
 Parsec is a game streaming application used to play video games remotely across a conntected network from a system in the cloud to your home computer. OSMC (short for Open Source Media Center) is a Linux distribution based on Debian that brings Kodi to a variety of devices. This addon brings the two together to create a seamless experience.
 
 ![Add-on Configuration](https://i.imgur.com/qm2vHi9.jpg)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# NO LONGER COMPATIBLE
-Hi folks, unfortunately it seems the Parsec team have made a lot of changes to Parsec recently that are good, but break compatability with this plugin for the time being. If and when Parsec becomes available for the Pi 4, I'll be able to resume development on this plugin, but for the time being this is defunct. Please feel free to fork and continue if you can!
-
 # Parsec Launcher for OSMC
 Parsec is a game streaming application used to play video games remotely across a conntected network from a system in the cloud to your home computer. OSMC (short for Open Source Media Center) is a Linux distribution based on Debian that brings Kodi to a variety of devices. This addon brings the two together to create a seamless experience.
 
@@ -17,11 +14,12 @@ Parsec is a game streaming application used to play video games remotely across 
 * Raspberry Pi Device
 * OSMC installed on your device - [Download & Installation Instructions](https://osmc.tv/download/).
 * Parsec installed on your device - [Download & Installation Instructions](https://support.parsecgaming.com/hc/en-us/articles/115002699012-Setting-Up-On-Raspberry-Pi-Raspbian-).
+* Install required dependencies via terminal/ssh: `sudo apt install libatomic1`
 * Parsec installed on a host machine or cloud instance to connect to.
 * USB keyboard (wired or wireless)
 
 ## Installation
-* Download production package **script.parsec.zip** [here](http://dev.grantgarrison.com/projects/script.parsec.zip).
+* Download **script.parsec.zip** from releases
 * Follow the addon installation instructions **HOW-TO:Install add-ons from zip files** [here](https://kodi.wiki/view/HOW-TO:Install_add-ons_from_zip_files).
 
 ## Configuration

--- a/parsec.py
+++ b/parsec.py
@@ -10,7 +10,7 @@ ADDON_NAME = ADDON.getAddonInfo('name')
 
 OS_USER = ADDON.getSetting('os_user')
 RESOURCE_PATH = xbmc.translatePath(SPECIAL_PATH)
-SERVER_ID = ADDON.getSetting('server_id')
+PEER_ID = ADDON.getSetting('peer_id')
 
 HEADLESS_MODE = ADDON.getSetting('headless_mode')
 
@@ -94,7 +94,7 @@ PARSEC_ARGS = PARSEC_BUTTON + ":" + KEYBOARD_PASSTHROUGH + ":" + WAN_QUALITY + "
 
 
 if HEADLESS_MODE == "true":
-    PARSEC_LAUNCHER = RESOURCE_PATH + "parsec-launcher.sh " + OS_USER + " " + RESOURCE_PATH + " server_id='" + SERVER_ID + "':" + PARSEC_ARGS
+    PARSEC_LAUNCHER = RESOURCE_PATH + "parsec-launcher.sh " + OS_USER + " " + RESOURCE_PATH + " peer_id='" + PEER_ID + "':" + PARSEC_ARGS
 else:
     PARSEC_LAUNCHER = RESOURCE_PATH + "parsec-launcher.sh " + OS_USER + " " + RESOURCE_PATH + " " + PARSEC_ARGS
 

--- a/resources/parsec.sh
+++ b/resources/parsec.sh
@@ -1,1 +1,1 @@
-sudo su $1 -c "parsec $2"; sudo systemctl start mediacenter;
+sudo su $1 -c "parsecd $2"; sudo systemctl start mediacenter;

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -2,7 +2,7 @@
 <settings>
     <category label="General">
         <setting label="Headless Client Mode" type="bool" id="headless_mode" default="false"/>
-        <setting label="Server ID (located in the 'Manage' window of Parsec on your host machine)" type="number" id="server_id" subsetting="true" default="00000"/>
+        <setting label="Peer ID" type="text" id="peer_id" subsetting="true" default="00000"/>
         <setting type="sep"/>
         <setting label="Parsec Button Overlay" type="bool" id="client_overlay" default="true"/>
         <setting label="Keyboard Shortcut Passthrough" type="bool" id="client_immersive" default="false"/>


### PR DESCRIPTION
- Fixed command to start parsec
- Edited settings to match parsec docs (now uses "Peer ID")
- Edited README to show new dependency requirement (libatomic1)